### PR TITLE
chore: suggest shell background running & other doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ written using [`rumps`](https://github.com/jaredks/rumps).
 ### Start the `kalimba` menu bar app
 
 ```bash
-$ kalimba --foreground
+$ kalimba
 INFO:kalimba.kalimba:Starting the kalimba app... 🎶
 ...
 ```

--- a/README.md
+++ b/README.md
@@ -39,21 +39,75 @@ poetry run kalimba --help # shows some tips-and-tricks
 poetry run kalimba # starts the app
 ```
 <!-- markdownlint-disable MD033 -->
+<details open="true">
+<summary><i>More temporary installation options</i> 👀</summary>
+
 <details>
-<summary><i>More temporary installation options 👀</i></summary>
+<summary><b>Using local build</b> 🪵</summary>
 
-#### Install via local pypiserver
+#### Install local build directly
 
-1. Configure `poetry`:
+1. Build the project
 
     ```bash
-    poetry config repositories.local http://localhost 
+    $ poetry build
+    Building kalimba (<version>)
+     ...
+     - Built kalimba-<version>-.tar.gz
+     ...
     ```
 
-2. Start the local [`pypi-server`](https://github.com/pypiserver/pypiserver)
+2. Check build results:
+
+    ```bash
+    $ ls ./dist
+    ...
+    kalimba-<version>-.tar.gz
+    ...
+    ```
+
+3. Install the local `tar` file:
+
+    > Don't forget to replace the `<version>` to the built result. 💡
+
+    ```bash
+    $ pip install --user ./dist/kalimba-<version>-.tar.gz
+    ...
+    Successfully installed ... kalimba-<version> ...
+    ```
+
+4. Check direct access to `kalimba` CLI
+
+    ```bash
+    $ kalimba --help
+
+    Usage: kalimba [OPTIONS]
+    ...
+    ```
+
+</details>
+
+<details>
+<summary><b>Using pypiserver</b> 🏕️</summary>
+
+#### Install via (local) [pypiserver](https://github.com/pypiserver/pypiserver)
+
+1. Start the local [`pypi-server`](https://github.com/pypiserver/pypiserver)
+
+    > This guide shows how to use a locally running pypiserver.  
+    > Feel free to skip to the next step if you already have one running elsewhere. ✌️
 
     ```bash
     docker run --rm -p 80:8080 pypiserver/pypiserver:latest run -P . -a . -vvv
+    ```
+
+2. Configure `poetry`:
+
+    > If you would like to use a remotely deployed one, feel free to
+    > adjust the pypiserver URLs here and further. 🔁
+
+    ```bash
+    poetry config repositories.local http://localhost 
     ```
 
 3. Build and publish the project
@@ -80,5 +134,6 @@ poetry run kalimba # starts the app
     ...
     ```
 
+</details>
 </details>
 <!-- markdownlint-enable MD033 -->

--- a/kalimba/cli.py
+++ b/kalimba/cli.py
@@ -28,17 +28,18 @@ def __run_foreground_kalimba(verbose: bool):
     "--detached",
     is_flag=True,
     default=False,
-    help="Run the Kalimba process in a detached (sub-process) mode",
+    help=f"Run the {APP_NAME} process in a detached (sub-process) mode",
 )
 @click.option(
     "-v",
     "--verbose",
     is_flag=True,
     default=False,
-    help="Run the Kalimba process with extended logging",
+    help=f"Run the {APP_NAME} process with extended logging",
 )
 def start(detached: bool, verbose: bool):
-    """Simple starter for Kalimba"""
+    # TODO(tech-debt): make sure Kalimba here is also taken from the APP_NAME variable.
+    """Simple starter for Kalimba (Colima Menu Bar) app"""
     logger.setLevel(l.DEBUG if verbose else l.INFO)
     runner = __run_detached_kalimba if detached else __run_foreground_kalimba
     runner(verbose)

--- a/kalimba/cli.py
+++ b/kalimba/cli.py
@@ -5,26 +5,30 @@ from kalimba.kalimba import run_kalimba
 
 l.basicConfig()
 logger = l.getLogger(__name__)
-logger.setLevel(l.INFO)
 
 APP_NAME = "kalimba"
 
 
 def __run_detached_kalimba(*_):
-    l.info(f"starting {APP_NAME} in detached mode")
-    raise NotImplementedError("Sorry... this is not yet implemented")
+    logger.debug(f"starting {APP_NAME} in detached mode")
+    raise NotImplementedError(
+        "Sorry... this is not yet implemented. "
+        + f"Please run {APP_NAME} as a shell background process with `&` for now."
+    )
 
 
 def __run_foreground_kalimba(verbose: bool):
-    l.info(f"starting {APP_NAME} in foreground mode")
+    logger.debug(f"starting {APP_NAME} in foreground mode")
     run_kalimba(verbose=verbose)
 
 
 @click.command()
 @click.option(
-    "--detached/--foreground",
+    "-d",
+    "--detached",
+    is_flag=True,
     default=False,
-    help="Run the Kalimba process in a detached (sub-process) or foreground mode",
+    help="Run the Kalimba process in a detached (sub-process) mode",
 )
 @click.option(
     "-v",
@@ -35,6 +39,7 @@ def __run_foreground_kalimba(verbose: bool):
 )
 def start(detached: bool, verbose: bool):
     """Simple starter for Kalimba"""
+    logger.setLevel(l.DEBUG if verbose else l.INFO)
     runner = __run_detached_kalimba if detached else __run_foreground_kalimba
     runner(verbose)
 


### PR DESCRIPTION
# What

Native `--detached` mode remains not implemented, **but!** now suggests a workaround. :D 

## Changes

- Removed the explicit `--foreground` option switch, which made the `--detached/--foreground` mode confusing, in favour of a single `-d --detached` option flag.
- Running the `kalimba --detached` now still throws `NotImplementedError` but suggests to use shell background process like `$ kalimba &`.
- Made small adjustments to documentation of the CLI app and the README.